### PR TITLE
chore: support Go 1.24 or above.

### DIFF
--- a/.github/workflows/check-code.yaml
+++ b/.github/workflows/check-code.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9" # v8.0.0
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - name: "Run spell check"
         run: "make spell-check"
@@ -56,10 +56,10 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:

--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
-      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+      - uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8" # v5.0.0
 
       - uses: "actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5" # v5.5.0
         with:

--- a/README.jp.md
+++ b/README.jp.md
@@ -124,7 +124,7 @@ func main() {
 
 ## Requirements
 
-- Go 1.23 以上.
+- Go 1.24 以上.
 - Docker (開発時)
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ func main() {
 
 ## Requirements
 
-- Go 1.23 or above.
+- Go 1.24 or above.
 - Docker (for Development)
 
 ## Install

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mythrnr/httprouter-group
 
-go 1.23
+go 1.24
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
## Summary by Copilot

This pull request updates the project to use Go 1.24 as the minimum required version and adds initial support for Go 1.25. It also upgrades the `actions/checkout` GitHub Action to v5.0.0 across all workflows. These changes ensure compatibility with newer Go versions and improve CI reliability.

**Go version updates:**

* Updated the minimum required Go version to 1.24 in `go.mod`, `README.md`, and `README.jp.md`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L128-R128) [[3]](diffhunk://#diff-1be2acdcd3d0a8bc52d6c676aea011d0a834cb1214f0ea54ad9b84cba155c6efL127-R127)
* Updated GitHub Actions workflows to test against Go 1.24 and 1.25, removing support for Go 1.23. (`.github/workflows/check-code.yaml`)

**CI/CD improvements:**

* Upgraded `actions/checkout` to v5.0.0 in all GitHub Actions workflows for improved security and performance. (`.github/workflows/check-code.yaml`, `.github/workflows/scan-vulnerabilities.yaml`) [[1]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L20-R20) [[2]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L31-R31) [[3]](diffhunk://#diff-45b06d4faed87be876f230537454c539cc8c6cd574aa2bf77cb66dca6d92f3b8L47-R47) [[4]](diffhunk://#diff-cc9d9d3c0c78f6b5ef4c43e5c23501e6420a0e25eff660af96e7fdaee9e519ddL17-R17)